### PR TITLE
update aicoe-ci config to enable sync release pipeline

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -8,3 +8,6 @@ build:
   registry-org: "modh"
   registry-project: "opendatahub-operator"
   registry-secret: "modh-pusher-secret"
+sibling:
+  sibling-project-org: "red-hat-data-services"
+  sibling-project: "odh-manifests"


### PR DESCRIPTION
update aicoe-ci config to enable sync release pipeline.
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

This pull request would enable the opendatahub-operator to release the odh-manifest component in synergy.  The tag release event in opendatahub-operator would start the tag release event in sibling repository odh-manifest. 