### PR TITLE
Add submodule for odh-manifests and include tarball in modh image

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -2,9 +2,9 @@ check:
   - thoth-build
 build:
   build-stratergy: "Dockerfile"
-  dockerfile-path: "build/Dockerfile.multistage"
+  dockerfile-path: "build/Dockerfile.modh"
   custom-tag: "latest"
   registry: "quay.io"
   registry-org: "modh"
-  registry-project: "opendatahub-operator"
+  registry-project: "odh-operator-image"
   registry-secret: "modh-pusher-secret"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "odh-manifests"]
+	path = odh-manifests
+	url = https://github.com/red-hat-data-services/odh-manifests

--- a/build/Dockerfile.modh
+++ b/build/Dockerfile.modh
@@ -10,6 +10,12 @@ RUN go mod vendor &&\
 
 RUN go build -o build/_output/bin/kfctl -gcflags all=-trimpath=/scratch -asmflags all=-trimpath=/scratch -mod=vendor github.com/kubeflow/kfctl/v3/cmd/manager
 
+# Add in the odh-manifests tarball
+RUN mkdir -p /opt/manifests &&\
+    tar -czf /opt/manifests/odh-manifests.tar.gz \
+        --exclude={.*,*.md,Makefile,Dockerfile,Containerfile,OWNERS,tests} \
+        odh-manifests
+
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ENV HOME=/opt/kfctl
 
@@ -20,6 +26,9 @@ RUN mkdir -p ${HOME} &&\
 WORKDIR ${HOME}
 
 COPY --from=builder /scratch/build/_output/bin/kfctl /usr/local/bin/kfctl
+COPY --from=builder /opt/manifests/odh-manifests.tar.gz /opt/manifests/
+RUN chown -R 1001:0 /opt/manifests &&\
+    chmod -R a+r /opt/manifests
 
 # Add a symlink here so that the image can be invoked multiple ways
 # Autobuilds do not support adding -p binary_name ... so we provide all known names


### PR DESCRIPTION
This allows us to build a single image for the "all in one" style operator instead of building the operator, the manifests image, and running a third multistage build to combine the two.